### PR TITLE
Future-proof against potential Prelude.foldl'

### DIFF
--- a/src/Data/Transaction.hs
+++ b/src/Data/Transaction.hs
@@ -33,21 +33,15 @@ module Data.Transaction
   ) where
 
 import Prelude hiding
-  ( all
+  ( Foldable(..)
+  , all
   , any
   , drop
   , dropWhile
   , filter
-  , foldMap
-  , foldl
-  , foldl1
-  , foldr
-  , foldr1
   , head
   , init
   , last
-  , length
-  , null
   , repeat
   , replicate
   , span


### PR DESCRIPTION
See https://github.com/haskell/core-libraries-committee/issues/167

This is, of course, a bit speculative at the moment, but given that the change does not involve CPP, it should not hurt to merge it early to simplify further impact assessment.